### PR TITLE
feat: Add character and weapon viewing screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,26 @@
         </div>
         <div class="menu-footer">
             <button id="upgrades-btn">Mejoras</button>
+            <button id="characters-btn">Personajes</button>
+            <button id="weapons-btn">Armas</button>
             <button id="bestiary-btn">Bestiario</button>
         </div>
+    </div>
+
+    <div id="character-selection-screen" class="screen" style="display: none;">
+        <h1>Elige tu Personaje</h1>
+        <div id="character-list" class="selection-list">
+            <!-- Los personajes se insertarán aquí dinámicamente -->
+        </div>
+        <button id="char-select-back-btn" class="back-btn">Volver</button>
+    </div>
+
+    <div id="weapon-view-screen" class="screen" style="display: none;">
+        <h1>Arsenal de Armas</h1>
+        <div id="weapon-list" class="selection-list">
+            <!-- Las armas se insertarán aquí dinámicamente -->
+        </div>
+        <button id="weapon-view-back-btn" class="back-btn">Volver</button>
     </div>
 
     <canvas id="gameCanvas" style="display: none;"></canvas>

--- a/src/data/characters.js
+++ b/src/data/characters.js
@@ -1,0 +1,82 @@
+export const characters = [
+  {
+    id: 1,
+    name: "Triángulo Valiente",
+    shape: {
+      type: 'polygon',
+      sides: 3,
+    },
+    stats: {
+      health: 100,
+      speed: 4,
+      damage_bonus: 0,
+      pickup_radius: 50, // Radio de recolección de gemas
+    },
+    ability: "Habilidad: Comienza con un nivel extra.",
+    description: "Un caballero equilibrado, listo para cualquier desafío."
+  },
+  {
+    id: 2,
+    name: "Cuadrado Robusto",
+    shape: {
+      type: 'polygon',
+      sides: 4,
+    },
+    stats: {
+      health: 150,
+      speed: 3,
+      damage_bonus: 0,
+      pickup_radius: 50,
+    },
+    ability: "Habilidad: +50% de vida máxima.",
+    description: "Lento pero muy resistente. Ideal para aguantar grandes oleadas."
+  },
+  {
+    id: 3,
+    name: "Pentágono Veloz",
+    shape: {
+      type: 'polygon',
+      sides: 5,
+    },
+    stats: {
+      health: 80,
+      speed: 6,
+      damage_bonus: 0,
+      pickup_radius: 60,
+    },
+    ability: "Habilidad: +25% de velocidad de movimiento.",
+    description: "Se mueve rápidamente por el campo de batalla, esquivando con facilidad."
+  },
+  {
+    id: 4,
+    name: "Hexágono Afortunado",
+    shape: {
+      type: 'polygon',
+      sides: 6,
+    },
+    stats: {
+      health: 100,
+      speed: 4,
+      damage_bonus: 0,
+      pickup_radius: 100,
+    },
+    ability: "Habilidad: Aumenta el radio de recolección de gemas.",
+    description: "La suerte siempre está de su lado, atrayendo la experiencia hacia él."
+  },
+  {
+    id: 5,
+    name: "Heptágono de Cristal",
+    shape: {
+      type: 'polygon',
+      sides: 7,
+    },
+    stats: {
+      health: 60,
+      speed: 4,
+      damage_bonus: 0.20, // 20% más de daño
+      pickup_radius: 50,
+    },
+    ability: "Habilidad: +20% de daño a todas las armas.",
+    description: "Frágil pero letal. Causa un daño inmenso a costa de su propia defensa."
+  }
+];

--- a/src/data/weapons.js
+++ b/src/data/weapons.js
@@ -2,12 +2,15 @@
 // El bucle principal se encargará de crear las instancias.
 export const weapons = {
     magicWand: {
-        name: "Magic Wand",
-        cooldown: 120,
+        id: 1,
+        name: "Varita Mágica",
+        shape: { type: 'circle', radius: 8 },
+        description: "Dispara un proyectil al enemigo más cercano.",
+        stats: { cooldown: 120, damage: 10, speed: 8 },
         attack: (player, enemies) => {
-            if (enemies.length === 0) return []; // Devuelve array vacío si no hay enemigos
+            if (enemies.length === 0) return [];
 
-            let nearestEnemy = enemies[0];
+            let nearestEnemy = null;
             let minDistance = Infinity;
 
             enemies.forEach(enemy => {
@@ -18,12 +21,84 @@ export const weapons = {
                 }
             });
 
+            if (!nearestEnemy) return [];
+
             const angle = Math.atan2(nearestEnemy.position.y - player.position.y, nearestEnemy.position.x - player.position.x);
-            // Devolver los datos para un nuevo proyectil.
             return [{
-                position: { x: player.position.x + player.width / 2, y: player.position.y + player.height / 2 },
-                velocity: { x: Math.cos(angle) * 8, y: Math.sin(angle) * 8 }
+                type: 'projectile',
+                position: { ...player.position },
+                velocity: { x: Math.cos(angle) * weapons.magicWand.stats.speed, y: Math.sin(angle) * weapons.magicWand.stats.speed },
+                damage: weapons.magicWand.stats.damage,
+                radius: 5
             }];
+        }
+    },
+    knives: {
+        id: 2,
+        name: "Cuchillos",
+        shape: { type: 'rectangle', width: 15, height: 5 },
+        description: "Lanza cuchillos en la dirección que mira el jugador.",
+        stats: { cooldown: 80, damage: 15, speed: 12 },
+        attack: (player, enemies) => {
+            // Asume que el jugador tiene una propiedad 'direction' (p.ej. 'right', 'left')
+            // Por ahora, lanzará hacia la derecha por defecto.
+            const directionX = player.direction === 'left' ? -1 : 1;
+            return [{
+                type: 'projectile',
+                position: { ...player.position },
+                velocity: { x: directionX * weapons.knives.stats.speed, y: 0 },
+                damage: weapons.knives.stats.damage,
+                width: 10,
+                height: 4
+            }];
+        }
+    },
+    garlic: {
+        id: 3,
+        name: "Ajo",
+        shape: { type: 'ring', outerRadius: 60, innerRadius: 50 },
+        description: "Crea un aura dañina alrededor del jugador.",
+        stats: { cooldown: 150, damage: 5, area: 100 },
+        attack: (player, enemies) => {
+            // El ajo no crea proyectiles, su lógica de daño se aplicará en el bucle principal
+            // basándose en la proximidad. Devolvemos un tipo especial.
+            return [{
+                type: 'aura',
+                position: { ...player.position },
+                radius: weapons.garlic.stats.area,
+                damage: weapons.garlic.stats.damage
+            }];
+        }
+    },
+    holyWater: {
+        id: 4,
+        name: "Agua Bendita",
+        shape: { type: 'square', size: 12 },
+        description: "Lanza un frasco que crea un área de daño en el suelo.",
+        stats: { cooldown: 180, damage: 8, duration: 300 }, // 5 segundos
+        attack: (player, enemies) => {
+            return [{
+                type: 'ground_area',
+                position: { x: player.position.x + Math.random() * 100 - 50, y: player.position.y + Math.random() * 100 - 50 },
+                radius: 80,
+                damage: weapons.holyWater.stats.damage,
+                duration: weapons.holyWater.stats.duration
+            }];
+        }
+    },
+    whip: {
+        id: 5,
+        name: "Látigo",
+        shape: { type: 'line', length: 100 },
+        description: "Ataca horizontalmente a ambos lados del jugador.",
+        stats: { cooldown: 100, damage: 20, range: 120 },
+        attack: (player, enemies) => {
+            // El látigo es un ataque instantáneo, no un proyectil persistente.
+            // Devolvemos un tipo especial para manejarlo en el bucle de colisiones.
+            return [
+                { type: 'hitbox', position: { ...player.position }, width: weapons.whip.stats.range, height: 20, side: 'left', damage: weapons.whip.stats.damage },
+                { type: 'hitbox', position: { ...player.position }, width: weapons.whip.stats.range, height: 20, side: 'right', damage: weapons.whip.stats.damage }
+            ];
         }
     }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -5,12 +5,24 @@ import { XPGem } from './components/XPGem.js';
 import { enemyTypes } from './data/enemies.js';
 import { waveTimeline } from './data/waves.js';
 import { weapons } from './data/weapons.js';
+import { characters } from './data/characters.js';
 
 window.addEventListener('DOMContentLoaded', () => {
     // --- DOM Elements ---
     const startScreen = document.getElementById('start-screen');
     const mainMenuScreen = document.getElementById('main-menu-screen');
+    const characterSelectionScreen = document.getElementById('character-selection-screen');
+    const weaponViewScreen = document.getElementById('weapon-view-screen');
+    const characterList = document.getElementById('character-list');
+    const weaponList = document.getElementById('weapon-list');
+
+    // Buttons
     const startGameBtn = document.getElementById('start-game-btn');
+    const charactersBtn = document.getElementById('characters-btn');
+    const weaponsBtn = document.getElementById('weapons-btn');
+    const charSelectBackBtn = document.getElementById('char-select-back-btn');
+    const weaponViewBackBtn = document.getElementById('weapon-view-back-btn');
+
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas.getContext('2d');
 
@@ -24,24 +36,141 @@ window.addEventListener('DOMContentLoaded', () => {
 
     function changeState(newState) {
         gameState = newState;
+        // Hide all screens first
+        startScreen.style.display = 'none';
+        mainMenuScreen.style.display = 'none';
+        characterSelectionScreen.style.display = 'none';
+        weaponViewScreen.style.display = 'none';
+        canvas.style.display = 'none';
+
+        // Show the correct screen
         switch (gameState) {
             case 'startScreen':
                 startScreen.style.display = 'flex';
-                mainMenuScreen.style.display = 'none';
-                canvas.style.display = 'none';
                 break;
             case 'mainMenu':
-                startScreen.style.display = 'none';
                 mainMenuScreen.style.display = 'flex';
-                canvas.style.display = 'none';
+                break;
+            case 'characterSelection':
+                characterSelectionScreen.style.display = 'flex';
+                break;
+            case 'weaponView':
+                weaponViewScreen.style.display = 'flex';
                 break;
             case 'running':
             case 'levelUp':
-                mainMenuScreen.style.display = 'none';
                 canvas.style.display = 'block';
                 break;
         }
     }
+
+    // --- UI Population ---
+    function drawPolygon(canvas, sides) {
+        const ctx = canvas.getContext('2d');
+        const width = canvas.width;
+        const height = canvas.height;
+        const centerX = width / 2;
+        const centerY = height / 2;
+        const radius = width / 2 * 0.8;
+
+        ctx.clearRect(0, 0, width, height);
+        ctx.beginPath();
+        ctx.moveTo(centerX + radius * Math.cos(0), centerY + radius * Math.sin(0));
+
+        for (let i = 1; i <= sides; i++) {
+            ctx.lineTo(
+                centerX + radius * Math.cos(i * 2 * Math.PI / sides),
+                centerY + radius * Math.sin(i * 2 * Math.PI / sides)
+            );
+        }
+
+        ctx.closePath();
+        ctx.strokeStyle = '#ffc107';
+        ctx.lineWidth = 3;
+        ctx.stroke();
+        ctx.fillStyle = 'rgba(255, 193, 7, 0.3)';
+        ctx.fill();
+    }
+
+    function drawWeaponShape(canvas, shape) {
+        const ctx = canvas.getContext('2d');
+        const width = canvas.width;
+        const height = canvas.height;
+        const centerX = width / 2;
+        const centerY = height / 2;
+
+        ctx.clearRect(0, 0, width, height);
+        ctx.strokeStyle = '#ff8a80';
+        ctx.lineWidth = 3;
+        ctx.fillStyle = 'rgba(255, 138, 128, 0.3)';
+
+        switch (shape.type) {
+            case 'circle':
+                ctx.beginPath();
+                ctx.arc(centerX, centerY, shape.radius * 2, 0, Math.PI * 2);
+                ctx.stroke();
+                ctx.fill();
+                break;
+            case 'rectangle':
+                ctx.strokeRect(centerX - shape.width, centerY - shape.height / 2, shape.width * 2, shape.height * 2);
+                ctx.fillRect(centerX - shape.width, centerY - shape.height / 2, shape.width * 2, shape.height * 2);
+                break;
+            case 'ring':
+                ctx.beginPath();
+                ctx.arc(centerX, centerY, shape.outerRadius / 2, 0, Math.PI * 2);
+                ctx.moveTo(centerX + shape.innerRadius / 2, centerY);
+                ctx.arc(centerX, centerY, shape.innerRadius / 2, 0, Math.PI * 2, true); // Counter-clockwise
+                ctx.stroke();
+                ctx.fill();
+                break;
+            case 'square':
+                 ctx.strokeRect(centerX - shape.size, centerY - shape.size, shape.size * 2, shape.size * 2);
+                 ctx.fillRect(centerX - shape.size, centerY - shape.size, shape.size * 2, shape.size * 2);
+                break;
+            case 'line':
+                ctx.beginPath();
+                ctx.moveTo(centerX - shape.length / 2, centerY);
+                ctx.lineTo(centerX + shape.length / 2, centerY);
+                ctx.stroke();
+                break;
+        }
+    }
+
+    function populateCharacterSelection() {
+        characterList.innerHTML = ''; // Clear existing
+        characters.forEach(char => {
+            const card = document.createElement('div');
+            card.className = 'character-card';
+            card.innerHTML = `
+                <canvas class="shape-canvas" id="canvas-char-${char.id}" width="100" height="100"></canvas>
+                <h2>${char.name}</h2>
+                <p>${char.description}</p>
+                <p class="ability">${char.ability}</p>
+            `;
+            characterList.appendChild(card);
+
+            const shapeCanvas = document.getElementById(`canvas-char-${char.id}`);
+            drawPolygon(shapeCanvas, char.shape.sides);
+        });
+    }
+
+    function populateWeaponView() {
+        weaponList.innerHTML = ''; // Clear existing
+        Object.values(weapons).forEach(weapon => {
+            const card = document.createElement('div');
+            card.className = 'weapon-card';
+            card.innerHTML = `
+                <canvas class="shape-canvas" id="canvas-weapon-${weapon.id}" width="100" height="100"></canvas>
+                <h2>${weapon.name}</h2>
+                <p>${weapon.description}</p>
+            `;
+            weaponList.appendChild(card);
+
+            const shapeCanvas = document.getElementById(`canvas-weapon-${weapon.id}`);
+            drawWeaponShape(shapeCanvas, weapon.shape);
+        });
+    }
+
 
     // --- Game Functions ---
     function init() {
@@ -188,13 +317,13 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Event Listeners ---
-    startScreen.addEventListener('click', () => {
-        changeState('mainMenu');
-    });
+    startScreen.addEventListener('click', () => changeState('mainMenu'));
+    startGameBtn.addEventListener('click', () => init());
+    charactersBtn.addEventListener('click', () => changeState('characterSelection'));
+    weaponsBtn.addEventListener('click', () => changeState('weaponView'));
+    charSelectBackBtn.addEventListener('click', () => changeState('mainMenu'));
+    weaponViewBackBtn.addEventListener('click', () => changeState('mainMenu'));
 
-    startGameBtn.addEventListener('click', () => {
-        init();
-    });
 
     window.addEventListener('keydown', ({ key: k }) => {
         const key = k.toLowerCase();
@@ -223,5 +352,7 @@ window.addEventListener('DOMContentLoaded', () => {
     });
 
     // --- Initial Setup ---
+    populateCharacterSelection();
+    populateWeaponView();
     changeState('startScreen');
 });

--- a/style.css
+++ b/style.css
@@ -97,3 +97,107 @@ canvas {
     font-size: 2.5rem;
     padding: 1.5rem 3rem;
 }
+
+/* --- Selection Screens --- */
+.screen {
+    display: none; /* Hidden by default */
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #0a0a2e;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem;
+    box-sizing: border-box;
+    overflow-y: auto;
+}
+
+.screen h1 {
+    color: #eee;
+    text-shadow: 2px 2px 4px #000;
+}
+
+.selection-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 2rem;
+    padding: 1rem;
+}
+
+.character-card {
+    background-color: #1a1a3e;
+    border: 2px solid #4a4a7f;
+    border-radius: 10px;
+    padding: 1.5rem;
+    width: 250px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.character-card .shape-canvas {
+    width: 100px;
+    height: 100px;
+    margin-bottom: 1rem;
+}
+
+.character-card h2 {
+    margin-top: 0;
+    color: #ffc107;
+}
+
+.character-card p {
+    margin: 0.5rem 0;
+}
+
+.character-card .ability {
+    font-style: italic;
+    color: #00e5ff;
+}
+
+.weapon-card {
+    background-color: #1a1a3e;
+    border: 2px solid #7f4a4a;
+    border-radius: 10px;
+    padding: 1.5rem;
+    width: 250px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.weapon-card .shape-canvas {
+    width: 100px;
+    height: 100px;
+    margin-bottom: 1rem;
+}
+
+.weapon-card h2 {
+    margin-top: 0;
+    color: #ff8a80;
+}
+
+.weapon-card p {
+    margin: 0.5rem 0;
+}
+
+.back-btn {
+    margin-top: 2rem;
+    background-color: #555;
+    color: white;
+    border: 2px solid #777;
+    padding: 1rem 2rem;
+    font-size: 1.2rem;
+    cursor: pointer;
+    transition: background-color 0.3s, border-color 0.3s;
+}
+
+.back-btn:hover {
+    background-color: #777;
+    border-color: #999;
+}


### PR DESCRIPTION
This commit builds out the main menu by adding screens for character selection and weapon viewing, as requested by the user.

- Adds "Personajes" and "Armas" buttons to the main menu.
- Creates a `character-selection-screen` that dynamically displays a list of 5 characters from a new data file (`src/data/characters.js`).
- Creates a `weapon-view-screen` that dynamically displays a list of 5 weapons from an updated data file (`src/data/weapons.js`).
- Implements visual placeholders for characters (polygons) and weapons (geometric shapes) using HTML canvas.
- Adds all necessary navigation logic in `src/main.js` to transition between the main menu and the new screens.